### PR TITLE
Fix Windows build and launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Windows 環境で実行可能な `ankenNaviCHO_win.exe` を生成する手順で
 
 ### 1. ビルド実行
 ```cmd
-win_build\build_app.bat
+cd win_build
+.\build_app.bat
 ```
 スクリプトが行うこと
 1. `.venv` を自動作成し依存パッケージをインストール

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -282,7 +282,6 @@ def run_app():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        preexec_fn=os.setsid,
         env=os.environ.copy()  # 現在の環境変数を子プロセスに継承
     )
     

--- a/win_build/ank_nav.spec
+++ b/win_build/ank_nav.spec
@@ -1,7 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 import os
 block_cipher = None
-project_root = os.getcwd()
+project_root = os.path.abspath(os.path.join(os.getcwd(), '..'))
 entry_script = os.path.join(project_root, 'app_launcher.py')
 extra_datas = [
     (os.path.join(project_root, 'static'), 'static'),
@@ -14,7 +14,18 @@ icon_file = os.path.join(project_root, 'original_icon.ico')
 a = Analysis([
     entry_script,
 ], pathex=[project_root], binaries=[], datas=extra_datas,
-    hiddenimports=['supabase', 'flask_login', 'semver'],
+    hiddenimports=[
+        'supabase',
+        'flask_login',
+        'semver',
+        'flask_bootstrap',
+        'flask_wtf',
+        'psutil',
+        'openai',
+        'atexit',
+        'msvcrt',
+        'chromedriver_manager'
+    ],
     hookspath=[], runtime_hooks=[], excludes=[], win_no_prefer_redirects=False,
     win_private_assemblies=False, cipher=block_cipher, noarchive=False)
 
@@ -23,5 +34,5 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(pyz, a.scripts, a.binaries, a.zipfiles, a.datas,
           name='ankenNaviCHO_win',
           debug=False, bootloader_ignore_signals=False,
-          strip=False, upx=True, console=False,
+          strip=False, upx=True, console=True,
           icon=icon_file)

--- a/win_build/build_app.bat
+++ b/win_build/build_app.bat
@@ -19,9 +19,9 @@ if not exist "%VENV_DIR%" (
 set PYI=%VENV_DIR%\Scripts\pyinstaller.exe
 
 REM --- icon conversion (.png -> .ico) ---
-python win_build\convert_icon.py
+python convert_icon.py
 
-%PYI% --noconfirm win_build\ank_nav.spec
+%PYI% --noconfirm ank_nav.spec
 
 if exist dist\ankenNaviCHO_win.exe (
   echo [DONE] dist\ankenNaviCHO_win.exe created.


### PR DESCRIPTION
## Summary
- update Windows build instructions in README
- adjust paths in build script
- fix project root and hidden imports in PyInstaller spec
- enable console for debugging
- drop Unix-specific `os.setsid` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`